### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/StudentProfile.js
+++ b/src/components/StudentProfile.js
@@ -13,6 +13,25 @@ import profilePhoto2 from '../images/anotherProfile.png';
 
 import CSO_member from './CSO_member';
 
+/**
+ * Only allows http(s) and relative URLs in image src attributes.
+ * Returns defaultImage if the URL contains a dangerous scheme.
+ */
+function sanitizeImageUrl(url, defaultImage) {
+  if (
+    typeof url !== 'string' ||
+    url.trim() === '' ||
+    url.startsWith('javascript:') ||
+    url.startsWith('data:') ||
+    url.startsWith('vbscript:')
+  ) {
+    return defaultImage;
+  }
+  // Accept relative URLs and absolute http(s)
+  const allowed = /^(https?:\/\/|\/)/i;
+  return allowed.test(url) ? url : defaultImage;
+}
+
 export default function StudentProfile() {
   const navigate = useNavigate();
 
@@ -367,8 +386,8 @@ export default function StudentProfile() {
           <section className="profie-page">
             <section className="profile-content">
               <section className="ProfilePhotos">
-                <img src={userInfo.coverPic} id="cover" alt="cover" />
-                <img src={userInfo.profilePic} id="profile" alt="profile" />
+                <img src={sanitizeImageUrl(userInfo.coverPic, coverPhoto2)} id="cover" alt="cover" />
+                <img src={sanitizeImageUrl(userInfo.profilePic, profilePhoto2)} id="profile" alt="profile" />
                 <img src={edit} onClick={handleEdit} id="editProfile" alt="edit profile" />
               </section>
 


### PR DESCRIPTION
Potential fix for [https://github.com/2663211/Clubs-Connect/security/code-scanning/10](https://github.com/2663211/Clubs-Connect/security/code-scanning/10)

The vulnerability should be addressed by sanitizing or validating the image URL before rendering it as the `src` attribute of an `<img>` element. The best fix is to use a validation function that only allows URLs with trusted schemes (typically `http`, `https`, and possibly relative URLs, but not `data:`, `javascript:`, or other schemata). 

In this file, implement a simple function (e.g., `sanitizeImageUrl`) that checks the URL and either passes it through if valid or falls back to a default/placeholder image if not. Apply this sanitization before rendering `userInfo.profilePic` and `userInfo.coverPic` as `src` values.

**Required changes:**  
- Add a helper function, e.g., `sanitizeImageUrl`, at the top of the file.
- Use this function in the JSX rendering of `img src={...}` in place of direct usage.
- No additional dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
