### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/2663211/Clubs-Connect/security/code-scanning/1](https://github.com/2663211/Clubs-Connect/security/code-scanning/1)

To fix the problem, an explicit `permissions` block must be added at the top level of your workflow, just below the `name` field (i.e., before the `on` key), or at the job level if different jobs need different permissions. In this workflow, the job only needs to check out the code and run npm commands, which require only read access to repository contents. The best fix is to add the following at the top of the file:
```yaml
permissions:
  contents: read
```
This ensures the GITHUB_TOKEN used in the workflow and its jobs can only read repository contents, which is the minimal required privilege. The change should be made immediately under the `name: Run Tests` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
